### PR TITLE
Bug when having font-family with !important

### DIFF
--- a/lib/visitors/font-family-generic.js
+++ b/lib/visitors/font-family-generic.js
@@ -18,7 +18,7 @@ module.exports = {
     var newnode = [node[0], node[1], [node[2][0]]];
 
     for (var i = 1; i < node[2].length; i++) {
-      var value = node[2][i][1].toLowerCase();
+      var value = (node[2][i][1] || "").toLowerCase();
       if (generic.indexOf(value) !== -1) {
         node[2][i][1] = value; // lowercase generic
         newnode[2].push(node[2][i]);


### PR DESCRIPTION
Applied a fix for issues causing JavaScript exception when using CSS rules like the following:

```
.dropdown {
    font-family: myfont Light !important
}
```
