### PR TITLE
If CSS is empty, return empty string, fixes #16

### DIFF
--- a/lib/shrink.js
+++ b/lib/shrink.js
@@ -62,9 +62,14 @@ function traverseAST(ast) {
 }
 
 exports.shrink = function shrink(css) {
-  var ast = gonzo.parse(css);
-  ast = traverseAST(ast);
-  return gonzo.toCSS(ast);
+  if (css.trim()) {
+    var ast = gonzo.parse(css);
+    ast = traverseAST(ast);
+    return gonzo.toCSS(ast);
+  } else {
+    // if css is empty, just return empty string
+    return '';
+  }
 };
 
 exports.shrinkAST = function shrinkAST(ast) {


### PR DESCRIPTION
Fixes the issue where it crashes when CSS is empty
