### PR TITLE
Do not process when there is no CSS to process

### DIFF
--- a/lib/shrink.js
+++ b/lib/shrink.js
@@ -62,6 +62,11 @@ function traverseAST(ast) {
 }
 
 exports.shrink = function shrink(css) {
+  // Don't process if there isn't any CSS to process
+  if (css.replace(/[ \t]/g, '').length === 0) {
+    return '';
+  }
+
   var ast = gonzo.parse(css);
   ast = traverseAST(ast);
   return gonzo.toCSS(ast);


### PR DESCRIPTION
`traverseAST()` would crash without error. It should return nothing if nothing is given.
